### PR TITLE
gh-103268: Add IPv4-IPv6 Translation

### DIFF
--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -2094,6 +2094,19 @@ class IPv6Address(_BaseV6, _BaseAddress):
             return None
         return IPv4Address((self._ip >> 80) & 0xFFFFFFFF)
 
+    @property
+    def ipv4_translation(self):
+        """Return the IPv4/IPv6 Translation embedded address.
+
+        Returns:
+            The IPv4/IPv6 Translation embedded address if present or None
+            if the address doesn't appear to contain a translation address.
+
+        """
+        if (self._ip >> 96) != 0x64FF9B:
+            return None
+        return IPv4Address(self._ip & 0xFFFFFFFF)
+
 
 class IPv6Interface(IPv6Address):
 


### PR DESCRIPTION
This does not handle translation with a Network-Specific Prefix, which must be known beforehand when embedding IPv4 addresses with RFC 6052.

https://www.rfc-editor.org/rfc/rfc6052.html#section-2.2
